### PR TITLE
feat: 体重トラッキング・トレーニング統計・CSVエクスポート機能を追加

### DIFF
--- a/prisma/migrations/20260506000000_add_body_weight/migration.sql
+++ b/prisma/migrations/20260506000000_add_body_weight/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "BodyWeight" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BodyWeight_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BodyWeight_userId_date_idx" ON "BodyWeight"("userId", "date");
+
+-- AddForeignKey
+ALTER TABLE "BodyWeight" ADD CONSTRAINT "BodyWeight_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,6 +137,18 @@ model Session {
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
+model BodyWeight {
+  id        String   @id @default(cuid())
+  userId    String
+  weight    Float
+  date      DateTime
+  note      String?
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+
+  @@index([userId, date])
+}
+
 model User {
   id            String         @id @default(cuid())
   name          String?
@@ -150,6 +162,7 @@ model User {
   goals         Goal[]
   weeklyReports WeeklyReport[]
   workoutMenus  WorkoutMenu[]
+  bodyWeights   BodyWeight[]
 }
 
 model VerificationToken {

--- a/src/app/body-weight-add/BodyWeightAddPage.tsx
+++ b/src/app/body-weight-add/BodyWeightAddPage.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "../../utils/api";
+import { Button, Subheader } from "../../components";
+
+export const BodyWeightAddPage: React.FC = () => {
+  const router = useRouter();
+  const today = new Date().toISOString().split("T")[0] ?? "";
+  const [weight, setWeight] = useState<string>("");
+  const [date, setDate] = useState<string>(today);
+  const [note, setNote] = useState<string>("");
+  const [error, setError] = useState<string>("");
+
+  const mutation = api.bodyWeight.add.useMutation({
+    onSuccess: () => {
+      router.push("/body-weight");
+    },
+  });
+
+  const handleSubmit = () => {
+    const parsed = parseFloat(weight);
+    if (isNaN(parsed) || parsed <= 0) {
+      setError("体重は正の数値を入力してください");
+      return;
+    }
+    if (!date) {
+      setError("日付を入力してください");
+      return;
+    }
+    setError("");
+    mutation.mutate({
+      weight: parsed,
+      date: new Date(date).toISOString(),
+      note: note || undefined,
+    });
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <Subheader content="体重を記録する" variant="section" />
+
+      <div className="flex flex-col gap-3 px-2">
+        <div>
+          <label className="block text-sm font-bold text-gray-700 dark:text-gray-300 mb-1" htmlFor="weight">
+            体重 (kg)
+          </label>
+          <input
+            id="weight"
+            type="number"
+            step="0.1"
+            min="0"
+            max="999"
+            placeholder="例: 70.5"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="w-full rounded border py-2 px-3 text-gray-700 shadow focus:outline-none dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-bold text-gray-700 dark:text-gray-300 mb-1" htmlFor="date">
+            日付
+          </label>
+          <input
+            id="date"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="w-full rounded border py-2 px-3 text-gray-700 shadow focus:outline-none dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-bold text-gray-700 dark:text-gray-300 mb-1" htmlFor="note">
+            メモ（任意）
+          </label>
+          <input
+            id="note"
+            type="text"
+            maxLength={200}
+            placeholder="例: 朝食前"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="w-full rounded border py-2 px-3 text-gray-700 shadow focus:outline-none dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          />
+        </div>
+
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+
+        <div className="flex gap-2">
+          <Button onClick={handleSubmit} disabled={mutation.isLoading}>
+            {mutation.isLoading ? "保存中..." : "保存"}
+          </Button>
+          <button
+            onClick={() => router.back()}
+            className="px-4 py-2 text-sm rounded border dark:border-gray-500 dark:text-gray-300"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/app/body-weight-add/page.tsx
+++ b/src/app/body-weight-add/page.tsx
@@ -1,0 +1,22 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "../../pages/api/auth/[...nextauth]";
+import { Container, Heading, Navigation } from "../../components/server";
+import { BodyWeightAddPage } from "./BodyWeightAddPage";
+
+export default async function Page() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect("/login");
+
+  return (
+    <>
+      <main className="md:mt-4">
+        <Heading />
+        <Navigation />
+        <Container>
+          <BodyWeightAddPage />
+        </Container>
+      </main>
+    </>
+  );
+}

--- a/src/app/body-weight/BodyWeightPage.tsx
+++ b/src/app/body-weight/BodyWeightPage.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { PlusIcon, TrashIcon } from "@heroicons/react/20/solid";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import { api } from "../../utils/api";
+import { EmptyState, Loading, NoDataCard, Subheader } from "../../components";
+
+const PERIOD_OPTIONS = [
+  { label: "1ヶ月", days: 30 },
+  { label: "3ヶ月", days: 90 },
+  { label: "6ヶ月", days: 180 },
+  { label: "1年", days: 365 },
+];
+
+export const BodyWeightPage: React.FC = () => {
+  const [days, setDays] = useState(90);
+
+  const { data: chartData, isLoading: chartLoading, refetch: refetchChart } =
+    api.bodyWeight.getUserBodyWeightsForChart.useQuery({ days });
+
+  const { data: list, isLoading: listLoading, refetch: refetchList } =
+    api.bodyWeight.getUserBodyWeights.useQuery({ take: 20 });
+
+  const deleteMutation = api.bodyWeight.delete.useMutation({
+    onSuccess: () => {
+      void refetchChart();
+      void refetchList();
+    },
+  });
+
+  const formattedChart = (chartData ?? []).map((r: { date: Date | string; weight: number }) => ({
+    date: new Date(r.date).toLocaleDateString("ja-JP", { month: "numeric", day: "numeric" }),
+    weight: r.weight,
+  }));
+
+  return (
+    <section className="flex flex-col gap-4">
+      <Subheader content="体重記録" variant="section" />
+
+      {/* 期間切り替え */}
+      <div className="flex gap-2 flex-wrap">
+        {PERIOD_OPTIONS.map((opt) => (
+          <button
+            key={opt.days}
+            onClick={() => setDays(opt.days)}
+            className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+              days === opt.days
+                ? "bg-blue-500 text-white"
+                : "bg-gray-100 dark:bg-gray-700 dark:text-gray-200"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* グラフ */}
+      {chartLoading && <Loading />}
+      {!chartLoading && formattedChart.length === 0 && (
+        <EmptyState
+          message="まだ体重が記録されていません"
+          description="体重を記録してグラフを表示しましょう"
+          icon={
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+            </svg>
+          }
+        />
+      )}
+      {!chartLoading && formattedChart.length > 0 && (
+        <div className="dark:bg-gray-900 rounded-lg p-2">
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={formattedChart} margin={{ top: 5, right: 15, left: -10, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+              <XAxis dataKey="date" fontSize={11} />
+              <YAxis domain={["auto", "auto"]} unit="kg" fontSize={11} />
+              <Tooltip formatter={(v: unknown) => [`${String(v)} kg`, "体重"]} />
+              <Line
+                type="monotone"
+                dataKey="weight"
+                stroke="#42bfec"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+                activeDot={{ r: 5 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* 記録一覧 */}
+      <Subheader content="記録一覧" variant="subsection" />
+      {listLoading && <Loading />}
+      {!listLoading && (
+        <ul className="flex flex-col gap-2">
+          {list && list.length > 0 ? (
+            list.map((r) => (
+              <li
+                key={r.id}
+                className="flex items-center justify-between px-4 py-3 bg-gray-100 dark:bg-gray-900 rounded-lg dark:text-white"
+              >
+                <div className="flex flex-col">
+                  <span className="text-lg font-bold text-[#42bfec]">{r.weight} kg</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    {new Date(r.date).toLocaleDateString("ja-JP")}
+                  </span>
+                  {r.note && <span className="text-sm mt-1">{r.note}</span>}
+                </div>
+                <button
+                  onClick={() => deleteMutation.mutate({ id: r.id })}
+                  className="p-2 text-red-400 hover:text-red-600"
+                  aria-label="削除"
+                >
+                  <TrashIcon className="w-5 h-5" />
+                </button>
+              </li>
+            ))
+          ) : (
+            <NoDataCard />
+          )}
+        </ul>
+      )}
+
+      {/* 追加ボタン */}
+      <div className="flex">
+        <Link
+          href="/body-weight-add"
+          className="flex items-center gap-1 text-sm px-4 py-2 rounded-full dark:bg-gray-700 dark:text-white"
+        >
+          <PlusIcon className="w-4 h-4" />
+          体重を記録する
+        </Link>
+      </div>
+    </section>
+  );
+};

--- a/src/app/body-weight/page.tsx
+++ b/src/app/body-weight/page.tsx
@@ -1,0 +1,22 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "../../pages/api/auth/[...nextauth]";
+import { Container, Heading, Navigation } from "../../components/server";
+import { BodyWeightPage } from "./BodyWeightPage";
+
+export default async function Page() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect("/login");
+
+  return (
+    <>
+      <main className="md:mt-4">
+        <Heading />
+        <Navigation />
+        <Container>
+          <BodyWeightPage />
+        </Container>
+      </main>
+    </>
+  );
+}

--- a/src/app/dashboard/DashboardPage.tsx
+++ b/src/app/dashboard/DashboardPage.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { api } from "../../utils/api";
-import { ListBulletIcon, PlusIcon } from "@heroicons/react/20/solid";
+import { ListBulletIcon, PlusIcon, FireIcon, CalendarIcon, ScaleIcon } from "@heroicons/react/20/solid";
 
 import {
     FloatingButton,
@@ -52,10 +52,50 @@ export const DashboardPage = (props: Props) => {
         isError: errorR,
     } = api.weeklyReport.getUserReports.useQuery();
 
+    const { data: stats, isLoading: loadingStats } = api.workout.getTrainingStats.useQuery();
+
 
     return (
         <>
             {(errorM && errorR) && <NotLoggedInCard />}
+            <section className="flex flex-col gap-2">
+                <Subheader content="トレーニング統計" variant="section"/>
+                {loadingStats && <Loading />}
+                {stats && (
+                    <div className="grid grid-cols-3 gap-2">
+                        <div className="flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-900 rounded-lg py-3 px-2">
+                            <FireIcon className="w-6 h-6 text-orange-400 mb-1" />
+                            <span className="text-2xl font-extrabold text-orange-400">{stats.streak}</span>
+                            <span className="text-xs text-gray-500 dark:text-gray-400 text-center">連続日数</span>
+                        </div>
+                        <div className="flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-900 rounded-lg py-3 px-2">
+                            <CalendarIcon className="w-6 h-6 text-blue-400 mb-1" />
+                            <span className="text-2xl font-extrabold text-blue-400">{stats.workoutsThisMonth}</span>
+                            <span className="text-xs text-gray-500 dark:text-gray-400 text-center">今月の記録数</span>
+                        </div>
+                        <div className="flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-900 rounded-lg py-3 px-2">
+                            <Link href="/body-weight" className="flex flex-col items-center">
+                                <ScaleIcon className="w-6 h-6 text-green-400 mb-1" />
+                                <span className="text-xs font-bold text-green-400">体重記録</span>
+                                <span className="text-xs text-gray-500 dark:text-gray-400 text-center">トラッキング</span>
+                            </Link>
+                        </div>
+                    </div>
+                )}
+                {stats && stats.topExercises.length > 0 && (
+                    <div className="bg-gray-100 dark:bg-gray-900 rounded-lg px-4 py-3">
+                        <p className="text-xs font-bold text-gray-500 dark:text-gray-400 mb-2">よくやる種目</p>
+                        <ul className="flex flex-col gap-1">
+                            {stats.topExercises.map((ex, i) => (
+                                <li key={ex.exerciseId} className="flex items-center justify-between dark:text-white text-sm">
+                                    <span>{i + 1}. {ex.name}</span>
+                                    <span className="text-xs text-gray-400">{ex.count}回</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </section>
             <section className="flex flex-col gap-2">
                 <Subheader content="今週のトレーニング履歴" variant="section"/>
                 <div className="dark:bg-black">

--- a/src/app/workout-history/WorkoutHistoryPage.tsx
+++ b/src/app/workout-history/WorkoutHistoryPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState } from "react";
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
+import { ChevronLeftIcon, ChevronRightIcon, ArrowDownTrayIcon } from "@heroicons/react/20/solid";
 import { api } from "../../utils/api";
 
 import { RecordCard, Loading, Paginator, NoDataCard, ListContainer, Subheader } from "../../components";
@@ -48,7 +48,17 @@ export const WorkoutHistoryPage: React.FC = () => {
 
   return (
     <section className="flex flex-col gap-2">
-      <Subheader content="トレーニング履歴" variant="section"/>
+      <div className="flex items-center justify-between">
+        <Subheader content="トレーニング履歴" variant="section"/>
+        <a
+          href="/api/export/workouts"
+          download
+          className="flex items-center gap-1 text-xs px-3 py-1.5 rounded-full bg-gray-100 dark:bg-gray-700 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+        >
+          <ArrowDownTrayIcon className="w-4 h-4" />
+          CSV
+        </a>
+      </div>
       <div className="px-2">
         <label
           className="block text-sm font-bold text-gray-700 dark:text-gray-300"

--- a/src/pages/api/export/workouts.ts
+++ b/src/pages/api/export/workouts.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]";
+import { prisma } from "../../../server/db";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const workouts = await prisma.workout.findMany({
+    where: { userId: session.user.id },
+    orderBy: { date: "desc" },
+    include: {
+      exercise: { select: { name: true } },
+    },
+  });
+
+  const header = "日付,種目,重量(kg),レップ数,セット数,ボリューム,メモ\n";
+  const rows = workouts
+    .map((w) => {
+      const date = new Date(w.date).toLocaleDateString("ja-JP");
+      const name = `"${w.exercise.name.replace(/"/g, '""')}"`;
+      const weight = w.weight ?? 0;
+      const volume = weight * w.reps * w.sets;
+      const note = `"${(w.note ?? "").replace(/"/g, '""')}"`;
+      return `${date},${name},${weight},${w.reps},${w.sets},${volume},${note}`;
+    })
+    .join("\n");
+
+  const csv = "﻿" + header + rows; // BOM for Excel
+
+  res.setHeader("Content-Type", "text/csv; charset=utf-8");
+  res.setHeader("Content-Disposition", `attachment; filename="workouts_${new Date().toISOString().split("T")[0]}.csv"`);
+  return res.status(200).send(csv);
+}

--- a/src/pages/api/export/workouts.ts
+++ b/src/pages/api/export/workouts.ts
@@ -35,7 +35,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const csv = "﻿" + header + rows; // BOM for Excel
 
+  const dateStr = new Date().toISOString().split("T")[0] ?? "";
   res.setHeader("Content-Type", "text/csv; charset=utf-8");
-  res.setHeader("Content-Disposition", `attachment; filename="workouts_${new Date().toISOString().split("T")[0]}.csv"`);
+  res.setHeader("Content-Disposition", `attachment; filename="workouts_${dateStr}.csv"`);
   return res.status(200).send(csv);
 }

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -8,6 +8,7 @@ import { bodyPartRouter } from "./routers/bodyPart";
 import { weeklyReportRouter } from "./routers/weeklyReport";
 import { workoutMenuRouter } from "./routers/workoutMenu";
 import { goalRouter } from "./routers/goal";
+import { bodyWeightRouter } from "./routers/bodyWeight";
 
 /**
  * This is the primary router for your server.
@@ -24,6 +25,7 @@ export const appRouter = createTRPCRouter({
   bodyPart: bodyPartRouter,
   weeklyReport: weeklyReportRouter,
   workoutMenu: workoutMenuRouter,
+  bodyWeight: bodyWeightRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/bodyWeight.ts
+++ b/src/server/api/routers/bodyWeight.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+export const bodyWeightRouter = createTRPCRouter({
+  add: protectedProcedure
+    .input(
+      z.object({
+        weight: z.number().positive().max(999),
+        date: z.string().datetime(),
+        note: z.string().max(200).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.prisma.bodyWeight.create({
+        data: {
+          userId: ctx.session.user.id,
+          weight: input.weight,
+          date: input.date,
+          note: input.note,
+        },
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.prisma.bodyWeight.deleteMany({
+        where: {
+          id: input.id,
+          userId: ctx.session.user.id,
+        },
+      });
+    }),
+
+  getUserBodyWeights: protectedProcedure
+    .input(
+      z.object({
+        take: z.number().optional(),
+        skip: z.number().optional(),
+      })
+    )
+    .query(({ ctx, input }) => {
+      return ctx.prisma.bodyWeight.findMany({
+        where: { userId: ctx.session.user.id },
+        orderBy: { date: "desc" },
+        take: input.take,
+        skip: input.skip ?? 0,
+      });
+    }),
+
+  getUserBodyWeightsForChart: protectedProcedure
+    .input(
+      z.object({
+        days: z.number().min(7).max(365).default(90),
+      })
+    )
+    .query(({ ctx, input }) => {
+      const since = new Date();
+      since.setDate(since.getDate() - input.days);
+      return ctx.prisma.bodyWeight.findMany({
+        where: {
+          userId: ctx.session.user.id,
+          date: { gte: since },
+        },
+        orderBy: { date: "asc" },
+        select: { id: true, weight: true, date: true, note: true },
+      });
+    }),
+});

--- a/src/server/api/routers/workout.ts
+++ b/src/server/api/routers/workout.ts
@@ -3,6 +3,16 @@ import type { DailyVolumeProp } from "../../../components/types";
 
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
+type TrainingStatRow = {
+  date: Date;
+};
+
+type TopExerciseRow = {
+  exerciseId: number;
+  name: string;
+  count: bigint;
+};
+
 type VolumeProp = {
   totalVolume: number
 };
@@ -161,6 +171,70 @@ export const workoutRouter = createTRPCRouter({
       const volume = ctx.prisma.$queryRaw<VolumeProp[]>`select sum("weight" * "reps" * "sets") "totalVolume" from "Workout" where "userId"=${ctx.session.user.id} and to_char(date,'YYYY-MM-DD')=${dateString} and weight > 0 group by date;`
       return volume;
     }),
+
+  getTrainingStats: protectedProcedure.query(async ({ ctx }) => {
+    const userId = ctx.session.user.id;
+
+    // 全ワークアウト日（重複排除）を取得して連続日数を計算
+    const dates = await ctx.prisma.$queryRaw<TrainingStatRow[]>`
+      SELECT DISTINCT date_trunc('day', date) AS date
+      FROM "Workout"
+      WHERE "userId" = ${userId}
+      ORDER BY date DESC
+    `;
+
+    let streak = 0;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    for (let i = 0; i < dates.length; i++) {
+      const d = new Date(dates[i]?.date ?? 0);
+      d.setHours(0, 0, 0, 0);
+      const expected = new Date(today);
+      expected.setDate(today.getDate() - i);
+      if (d.getTime() === expected.getTime()) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+
+    // 今月のトレーニング日数
+    const firstOfMonth = new Date();
+    firstOfMonth.setDate(1);
+    firstOfMonth.setHours(0, 0, 0, 0);
+    const workoutsThisMonth = await ctx.prisma.workout.count({
+      where: {
+        userId,
+        date: { gte: firstOfMonth },
+      },
+    });
+
+    // 総ワークアウト記録数
+    const totalWorkouts = await ctx.prisma.workout.count({ where: { userId } });
+
+    // 最も多く記録したエクササイズ（上位3件）
+    const topExercises = await ctx.prisma.$queryRaw<TopExerciseRow[]>`
+      SELECT w."exerciseId", e.name, COUNT(*) AS count
+      FROM "Workout" w
+      JOIN "Exercise" e ON e.id = w."exerciseId"
+      WHERE w."userId" = ${userId}
+      GROUP BY w."exerciseId", e.name
+      ORDER BY count DESC
+      LIMIT 3
+    `;
+
+    return {
+      streak,
+      workoutsThisMonth,
+      totalWorkouts,
+      topExercises: topExercises.map(r => ({
+        exerciseId: r.exerciseId,
+        name: r.name,
+        count: Number(r.count),
+      })),
+    };
+  }),
 
   getUserWorkoutVolumeByExerciseId: protectedProcedure.input(
     z.object({


### PR DESCRIPTION
- BodyWeightモデルをPrismaスキーマに追加（マイグレーション付き）
- bodyWeightルーター: 追加/削除/一覧/チャート用データ取得
- /body-weight: 体重推移グラフ（Recharts折れ線）＋記録一覧・削除
- /body-weight-add: 体重記録フォーム（日付・メモ対応）
- workoutルーターにgetTrainingStats追加: 連続日数・今月記録数・よく使う種目Top3
- ダッシュボードに統計カード（連続日数・今月記録数・体重トラッキングへのリンク）を追加
- /api/export/workouts: ワークアウト全記録をCSVダウンロード（BOM付きUTF-8）
- ワークアウト履歴ページにCSVエクスポートボタンを追加

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP