### PR TITLE
style: ExerciseChartのレイアウトをサイトのデザインに統一

### DIFF
--- a/src/app/dashboard/DashboardPage.tsx
+++ b/src/app/dashboard/DashboardPage.tsx
@@ -98,7 +98,7 @@ export const DashboardPage = (props: Props) => {
             </section>
             <section className="flex flex-col gap-2">
                 <Subheader content="今週のトレーニング履歴" variant="section"/>
-                <div className="dark:bg-black">
+                <div>
                     {!isEmptyData ? (
                         <ExerciseChart chartData={chartData} />
                     ) : (

--- a/src/app/exercise-detail/ExerciseDetailPage.tsx
+++ b/src/app/exercise-detail/ExerciseDetailPage.tsx
@@ -103,7 +103,7 @@ export const ExerciseDetailPage: React.FC = () => {
                                 <option value="02">全期間</option>
                             </select>
                         </div>
-                        <div className="dark:bg-black">
+                        <div>
                             <ExerciseChart chartData={chartData} />
                         </div>
                     </div>

--- a/src/components/ExerciseChart.tsx
+++ b/src/components/ExerciseChart.tsx
@@ -17,56 +17,83 @@ type Props = {
     chartData: Partial<ChartProp>[];
 };
 
-
 export const ExerciseChart: React.FC<Props> = (props: Props) => {
     const { chartData } = props;
 
-    return (<>
-        <ResponsiveContainer
-            width="100%"
-            height={300}>
-            <ComposedChart
-                data={chartData}
-                margin={{ top: 5, right: 15, left: -5, bottom: 40 }}>
-                <XAxis
-                    dataKey="date"
-                    domain={['dataMin - 86400000', 'dataMax + 86400000']}
-                    interval={0}
-                    tickFormatter={(unixTime: Date) => new Date(unixTime).toISOString().split('T')[0] || ''}
-                    type="number"
-                    fontSize={12}
-                    angle={-45}
-                    textAnchor="end" 
-                     />
-                {/* <YAxis
-                    yAxisId={2}
-                    orientation="right"
-                    type="number"
-                    dataKey="volume"
-                    domain={[0, 'auto']} /> */}
-                <YAxis
-                    yAxisId={3}
-                    type="number"
-                    orientation="right"
-                    dataKey="cumulativeVolume"
-                    fontSize={12}
-                    domain={[0, 'auto']} />
-                <YAxis
-                    yAxisId={1}
-                    interval={0}
-                    orientation="left"
-                    type="number"
-                    dataKey="maximum"
-                    fontSize={12}
-                    domain={['dataMin - 5', 'dataMax + 5']} />
-                {/* <Bar yAxisId={2} dataKey="volume" barSize={20} fill="#413ea0" /> */}
-                <CartesianGrid strokeDasharray="3 3" />
-                <Bar yAxisId={3} type="monotone" dataKey="cumulativeVolume" barSize={20} fill="#413ea0" />
-                <Line yAxisId={1} type="monotone" dataKey="maximum" />
-                <Legend align="center" verticalAlign="top" fontSize={12} />
-                <Tooltip
-                    labelFormatter={(unixTime: Date) => new Date(unixTime).toLocaleDateString()} />
-            </ComposedChart>
-        </ResponsiveContainer>
-    </>);
+    return (
+        <div className="dark:bg-gray-900 rounded-lg p-2">
+            <ResponsiveContainer width="100%" height={280}>
+                <ComposedChart
+                    data={chartData}
+                    margin={{ top: 10, right: 20, left: -15, bottom: 5 }}
+                >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+                    <XAxis
+                        dataKey="date"
+                        domain={["dataMin - 86400000", "dataMax + 86400000"]}
+                        tickFormatter={(unixTime: number) =>
+                            new Date(unixTime).toLocaleDateString("ja-JP", {
+                                month: "numeric",
+                                day: "numeric",
+                            })
+                        }
+                        type="number"
+                        fontSize={11}
+                    />
+                    <YAxis
+                        yAxisId={3}
+                        orientation="right"
+                        dataKey="cumulativeVolume"
+                        fontSize={11}
+                        domain={[0, "auto"]}
+                        tickFormatter={(v: number) => v >= 1000 ? `${Math.round(v / 1000)}k` : String(v)}
+                    />
+                    <YAxis
+                        yAxisId={1}
+                        orientation="left"
+                        dataKey="maximum"
+                        fontSize={11}
+                        domain={["dataMin - 5", "dataMax + 5"]}
+                        unit="kg"
+                    />
+                    <Bar
+                        yAxisId={3}
+                        dataKey="cumulativeVolume"
+                        barSize={16}
+                        fill="#3b82f6"
+                        fillOpacity={0.7}
+                        radius={[2, 2, 0, 0]}
+                        name="累積ボリューム"
+                    />
+                    <Line
+                        yAxisId={1}
+                        type="monotone"
+                        dataKey="maximum"
+                        stroke="#42bfec"
+                        strokeWidth={2}
+                        dot={{ r: 3 }}
+                        activeDot={{ r: 5 }}
+                        name="最大重量(kg)"
+                    />
+                    <Legend
+                        align="center"
+                        verticalAlign="top"
+                        wrapperStyle={{ fontSize: "11px", paddingBottom: "8px" }}
+                    />
+                    <Tooltip
+                        labelFormatter={(unixTime: number) =>
+                            new Date(unixTime).toLocaleDateString("ja-JP")
+                        }
+                        formatter={(value: unknown, name: string) => {
+                            const v = typeof value === "number" ? value : Number(value);
+                            return [
+                                name === "累積ボリューム" ? v.toLocaleString() : `${v} kg`,
+                                name,
+                            ];
+                        }}
+                    />
+                </ComposedChart>
+            </ResponsiveContainer>
+        </div>
+    );
 };


### PR DESCRIPTION
- dark:bg-gray-900 + rounded-lg ラッパーを追加（BodyWeightPageに合わせる）
- CartesianGridにstroke="#374151"を追加しダークモード対応
- XAxisのラベル回転（-45°）を廃止、ja-JP短形式（M/D）に変更
- Barをblue-500・70%透明・上角丸に変更しモダンな見た目に
- Lineをstroke="#42bfec"・strokeWidth=2・dot付きに変更
- Legendのフォントを11pxに統一、paddingBottomを追加
- Tooltipをja-JP日付形式にし、累積ボリュームはカンマ区切り・最大重量はkg単位で表示
- YAxis右軸に1k形式の短縮フォーマットを追加
- 親コンポーネントの不要なdark:bg-blackラッパーを削除

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP