### PR TITLE
Add landing page content and dashboard onboarding tour

### DIFF
--- a/src/app/dashboard/DashboardPage.tsx
+++ b/src/app/dashboard/DashboardPage.tsx
@@ -18,8 +18,17 @@ import {
     EmptyState
 } from "../../components";
 import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import type { ChartProp } from "../../components/types";
 import type { Goal } from "@prisma/client";
+
+
+
+type TourStep = {
+    title: string;
+    description: string;
+    targetId: string;
+};
 
 type Props = {
     isEmptyData: boolean;
@@ -30,6 +39,37 @@ type Props = {
 export const DashboardPage = (props: Props) => {
     const { isEmptyData, userWorkoutVolumesInThisWeek, goal } = props;
     const router = useRouter();
+    const [tourOpen, setTourOpen] = useState(false);
+    const [tourStepIndex, setTourStepIndex] = useState(0);
+
+    const tourSteps = useMemo<TourStep[]>(() => ([
+        { title: "統計", description: "ここで連続日数や今月の記録数を確認できます。", targetId: "tour-stats" },
+        { title: "履歴グラフ", description: "週次のトレーニング推移を可視化できます。", targetId: "tour-chart" },
+        { title: "目標", description: "達成したい目標を登録して継続につなげましょう。", targetId: "tour-goal" },
+        { title: "記録を追加", description: "右下のボタンから素早く新規ワークアウトを追加できます。", targetId: "tour-add-workout" },
+    ]), []);
+
+    useEffect(() => {
+        const done = localStorage.getItem("everyworkout-onboarding-v1");
+        if (!done) {
+            setTourOpen(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!tourOpen) return;
+        const targetId = tourSteps[tourStepIndex]?.targetId;
+        if (!targetId) return;
+        const target = document.getElementById(targetId);
+        target?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, [tourOpen, tourStepIndex, tourSteps]);
+
+    const closeTour = () => {
+        localStorage.setItem("everyworkout-onboarding-v1", "done");
+        setTourOpen(false);
+    };
+
+    const currentStep = tourSteps[tourStepIndex];
 
     const chartData = userWorkoutVolumesInThisWeek.map(x => {
         return {
@@ -58,7 +98,7 @@ export const DashboardPage = (props: Props) => {
     return (
         <>
             {(errorM && errorR) && <NotLoggedInCard />}
-            <section className="flex flex-col gap-2">
+            <section id="tour-stats" className="flex flex-col gap-2">
                 <Subheader content="トレーニング統計" variant="section"/>
                 {loadingStats && <Loading />}
                 {stats && (
@@ -96,7 +136,7 @@ export const DashboardPage = (props: Props) => {
                     </div>
                 )}
             </section>
-            <section className="flex flex-col gap-2">
+            <section id="tour-chart" className="flex flex-col gap-2">
                 <Subheader content="今週のトレーニング履歴" variant="section"/>
                 <div>
                     {!isEmptyData ? (
@@ -120,7 +160,7 @@ export const DashboardPage = (props: Props) => {
                     </Link>
                 </div>
             </section>
-            <section className="flex flex-col gap-2">
+            <section id="tour-goal" className="flex flex-col gap-2">
                 <Subheader content="目標" variant="section"/>
                 {goal ? <>
                     <section key={goal.id} className="flex justify-between mx-1 px-2 py-4 bg-gray-100 rounded-lg dark:bg-gray-900 dark:outline outline-1 outline-gray-500 dark:text-white">
@@ -190,9 +230,38 @@ export const DashboardPage = (props: Props) => {
                     </>
                 )}
             </section>
-            <FloatingButton href="/workout-add">
+            <div id="tour-add-workout">
+                <FloatingButton href="/workout-add">
                 <PlusIcon className="w-10 h-10 text-white dark:text-gray-900"></PlusIcon>
             </FloatingButton>
+            </div>
+
+            {tourOpen && currentStep && (
+                <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 p-4 md:items-center">
+                    <div className="w-full max-w-md rounded-xl bg-white p-5 shadow-xl dark:bg-gray-800">
+                        <p className="text-xs text-gray-500 dark:text-gray-300">
+                            オンボーディング {tourStepIndex + 1} / {tourSteps.length}
+                        </p>
+                        <h3 className="mt-1 text-lg font-bold dark:text-white">{currentStep.title}</h3>
+                        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{currentStep.description}</p>
+                        <div className="mt-4 flex justify-between gap-2">
+                            <button className="rounded-md px-3 py-2 text-sm text-gray-500" onClick={closeTour}>スキップ</button>
+                            <button
+                                className="rounded-md bg-blue-500 px-3 py-2 text-sm font-semibold text-white"
+                                onClick={() => {
+                                    if (tourStepIndex === tourSteps.length - 1) {
+                                        closeTour();
+                                        return;
+                                    }
+                                    setTourStepIndex((prev) => prev + 1);
+                                }}
+                            >
+                                {tourStepIndex === tourSteps.length - 1 ? "開始する" : "次へ"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </>
     );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,21 +5,51 @@ import Image from "next/image";
 import Link from "next/link";
 import { AuthShowcase } from "../components";
 
+const features = [
+  {
+    title: "記録が1分で完了",
+    description: "セット・回数・重量をすばやく入力して、毎日のトレーニングを習慣化。",
+  },
+  {
+    title: "成長を可視化",
+    description: "今週の推移グラフと自己ベストで、伸びているポイントがすぐ分かります。",
+  },
+  {
+    title: "目標管理まで一体化",
+    description: "目標の作成・更新・振り返りを一つのアプリで完結できます。",
+  },
+];
+
 const Home: NextPage = () => {
   return (
-    <>
-        <main id="lp" className="flex min-h-screen flex-col items-center justify-center bg-white dark:bg-gray-900">
-          <div className="container flex flex-col items-center justify-center">
-            <Image src="/logo_v.png" alt="logo" width={500} height={100} />
-            <div className="flex flex-col items-center gap-2">
-              <AuthShowcase />
-              <Link className="dark:text-white" href="https://everyworkout-docs.netlify.app/" target="_blank">ユーザーズガイド</Link>
-            </div>
-          </div>
-        </main>
-    </>
+    <main id="lp" className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-white">
+      <section className="mx-auto flex w-full max-w-5xl flex-col items-center px-6 pb-16 pt-12 text-center">
+        <Image src="/logo_v.png" alt="EveryWorkout ロゴ" width={420} height={84} priority />
+        <p className="mt-6 max-w-2xl text-lg text-gray-600 dark:text-gray-300">
+          EveryWorkoutは、筋トレ記録・体重管理・目標達成をまとめてサポートする
+          トレーニング記録アプリです。
+        </p>
+        <div className="mt-8 flex flex-col items-center gap-3">
+          <AuthShowcase />
+          <Link className="text-sm underline underline-offset-4" href="https://everyworkout-docs.netlify.app/" target="_blank">
+            ユーザーズガイドを見る
+          </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto grid w-full max-w-5xl gap-4 px-6 pb-20 md:grid-cols-3">
+        {features.map((feature) => (
+          <article
+            key={feature.title}
+            className="rounded-xl border border-gray-200 bg-gray-50 p-5 text-left dark:border-gray-700 dark:bg-gray-800"
+          >
+            <h2 className="mb-2 text-lg font-bold">{feature.title}</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-300">{feature.description}</p>
+          </article>
+        ))}
+      </section>
+    </main>
   );
 };
 
 export default Home;
-


### PR DESCRIPTION
### Motivation
- Improve first-time user experience by providing a clearer landing page that communicates product value and features. 
- Guide new users through the Dashboard key areas so they can quickly discover stats, history, goals and how to add a workout. 
- Ensure the tour only appears once per user by persisting completion state.

### Description
- Replaced the root page layout with a focused landing layout containing logo, product copy, auth CTA and feature cards in `src/app/page.tsx`.
- Implemented a simple onboarding tour on the Dashboard in `src/app/dashboard/DashboardPage.tsx` that defines `TourStep`, shows a modal overlay with step title/description, and supports `スキップ`/`次へ`/`開始する` actions. 
- Added `id` attributes to dashboard sections (`tour-stats`, `tour-chart`, `tour-goal`, `tour-add-workout`) and automatic scroll-to-target behavior using `scrollIntoView`. 
- Persist tour completion using `localStorage` key `everyworkout-onboarding-v1` so the tour is shown only once per user.

### Testing
- Ran TypeScript type-check with `yarn exec tsc --noEmit`; the run reported failures due to pre-existing unrelated type errors in `src/app/body-weight/BodyWeightPage.tsx` and `src/server/api/routers/bodyWeight.ts`, so type-check did not fully pass. 
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faec95bc98832787793df325309b83)