### PR TITLE
feat: 有酸素運動の記録機能を追加

### DIFF
--- a/prisma/migrations/20260509000000_add_cardio_fields/migration.sql
+++ b/prisma/migrations/20260509000000_add_cardio_fields/migration.sql
@@ -1,0 +1,6 @@
+-- Add duration and calories columns to Workout table
+-- duration: integer minutes, null = strength workout
+-- calories: float kcal, null = not recorded
+ALTER TABLE "Workout"
+  ADD COLUMN "duration" INTEGER,
+  ADD COLUMN "calories" DOUBLE PRECISION;

--- a/prisma/migrations/20260509000001_add_cardio_exercises/migration.sql
+++ b/prisma/migrations/20260509000001_add_cardio_exercises/migration.sql
@@ -1,0 +1,24 @@
+-- Add aerobic/cardio exercise category and exercises
+
+INSERT INTO "BodyPart" ("name") VALUES ('有酸素運動');
+
+INSERT INTO "Muscle" ("name", "name_kana", "bodyPartId")
+  SELECT '全身', 'ぜんしん', id FROM "BodyPart" WHERE name = '有酸素運動';
+
+INSERT INTO "Exercise" ("name") VALUES
+  ('ランニング'),
+  ('ウォーキング'),
+  ('サイクリング'),
+  ('水泳'),
+  ('ロープジャンプ'),
+  ('エアロバイク'),
+  ('ローイングマシン');
+
+INSERT INTO "ExerciseMuscle" ("exerciseId", "muscleId", "is_main")
+  SELECT e.id, m.id, true
+  FROM "Exercise" e, "Muscle" m
+  WHERE e.name IN (
+    'ランニング', 'ウォーキング', 'サイクリング', '水泳',
+    'ロープジャンプ', 'エアロバイク', 'ローイングマシン'
+  )
+  AND m.name = '全身';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,8 @@ model Workout {
   sets                  Int
   note                  String?
   exerciseId            Int
+  duration              Int?
+  calories              Float?
   weeklyReportPublished Boolean  @default(false)
   createdAt             DateTime @default(now())
   exercise              Exercise @relation(fields: [exerciseId], references: [id])

--- a/src/app/cardio-add/CardioAddPage.tsx
+++ b/src/app/cardio-add/CardioAddPage.tsx
@@ -1,0 +1,188 @@
+"use client";
+import React, { useState, useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  Button,
+  ExerciseSelector,
+  Loading,
+} from "../../components";
+import { api } from "../../utils/api";
+import { useExerciseSelector } from "../../hooks/useExerciseSelector";
+import { revalidate } from "../actions";
+
+export const CardioAddPage: React.FC = () => {
+  const router = useRouter();
+  const [date, setDate] = useState<string>(
+    new Date().toISOString().split("T")[0] || ""
+  );
+  const [duration, setDuration] = useState<string>("");
+  const [calories, setCalories] = useState<string>("");
+  const [note, setNote] = useState<string>("");
+  const [validationError, setValidationError] = useState<string>("");
+
+  const { data: bodyParts } = api.bodyPart.getAll.useQuery();
+  const { data: muscles } = api.muscle.getAllExercises.useQuery();
+  const { data: exercises } = api.exercise.getAll.useQuery();
+
+  const {
+    selectedExerciseId,
+    selectExerciseId,
+    selectedBodyPartId,
+    selectBodyPartId,
+  } = useExerciseSelector(exercises || []);
+
+  useEffect(() => {
+    if (bodyParts) {
+      const cardioBodyPart = bodyParts.find(bp => bp.name === '有酸素運動');
+      if (cardioBodyPart) {
+        selectBodyPartId(cardioBodyPart.id);
+      }
+    }
+  }, [bodyParts, selectBodyPartId]);
+
+  const mutation = api.workout.add.useMutation({
+    async onSuccess({ id }) {
+      await revalidate('/dashboard');
+      return router.push(`/workout-detail?id=${id}`);
+    },
+  });
+
+  const send = async () => {
+    if (selectedExerciseId < 0) {
+      setValidationError("種目を選んでください");
+      return;
+    }
+    const durationInt = parseInt(duration);
+    if (!duration || isNaN(durationInt) || durationInt <= 0) {
+      setValidationError("時間（分）を正しく入力してください");
+      return;
+    }
+    setValidationError("");
+    await mutation
+      .mutateAsync({
+        date: new Date(date).toISOString(),
+        reps: 0,
+        sets: 0,
+        note: note,
+        exerciseId: selectedExerciseId,
+        duration: durationInt,
+        calories: calories ? parseFloat(calories) : undefined,
+      })
+      .catch(() => {
+        return;
+      });
+  };
+
+  const handleExerciseClick = useCallback((exerciseId: number) => {
+    selectExerciseId(exerciseId);
+  }, [selectExerciseId]);
+
+  const handleBodyPartClick = (id: number) => {
+    selectBodyPartId(id);
+  };
+
+  return (
+    <div className="m-2 flex flex-col gap-2">
+      {(mutation.isError || validationError) && (
+        <p className="rounded-lg bg-red-100 p-4 text-red-900">
+          {validationError || "エラーが発生しました。もう一度お試しください。"}
+        </p>
+      )}
+      <div className="grid gap-2">
+        <label
+          className="block text-sm font-bold text-gray-700 dark:text-gray-300"
+          htmlFor="date"
+        >
+          日付
+        </label>
+        <input
+          className="focus:shadow-outline w-full appearance-none rounded border py-2 px-3 leading-tight
+                text-gray-700 shadow focus:outline-none
+                dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          id="date"
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-bold text-gray-700 dark:text-gray-300">
+          種目
+        </label>
+        {bodyParts && muscles && (
+          <ExerciseSelector
+            selectedExerciseId={selectedExerciseId}
+            selectedBodyPartId={selectedBodyPartId}
+            bodyParts={bodyParts}
+            muscles={muscles}
+            handleExerciseClick={handleExerciseClick}
+            handleBodyPartClick={handleBodyPartClick}
+          />
+        )}
+      </div>
+      <div className="grid gap-2">
+        <label
+          className="block text-sm font-bold text-gray-700 dark:text-gray-300"
+          htmlFor="duration"
+        >
+          時間（分）
+        </label>
+        <input
+          className="focus:shadow-outline w-full appearance-none rounded border py-2 px-3 leading-tight
+                text-gray-700 shadow focus:outline-none
+                dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          id="duration"
+          type="number"
+          min="1"
+          placeholder="例: 30"
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+        />
+      </div>
+      <div className="grid gap-2">
+        <label
+          className="block text-sm font-bold text-gray-700 dark:text-gray-300"
+          htmlFor="calories"
+        >
+          消費カロリー（kcal）（任意）
+        </label>
+        <input
+          className="focus:shadow-outline w-full appearance-none rounded border py-2 px-3 leading-tight
+                text-gray-700 shadow focus:outline-none
+                dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          id="calories"
+          type="number"
+          min="0"
+          step="1"
+          placeholder="例: 250"
+          value={calories}
+          onChange={(e) => setCalories(e.target.value)}
+        />
+      </div>
+      <div className="grid gap-2">
+        <label
+          className="block text-sm font-bold text-gray-700 dark:text-gray-300"
+          htmlFor="note"
+        >
+          メモ
+        </label>
+        <input
+          className="focus:shadow-outline w-full appearance-none rounded border py-2 px-3 leading-tight
+                text-gray-700 shadow focus:outline-none
+                dark:bg-gray-700 dark:text-white dark:border-gray-500"
+          id="note"
+          type="text"
+          placeholder="メモ"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+      </div>
+      {mutation.isLoading ? (
+        <Loading />
+      ) : (
+        <Button onClick={() => void send()}>登録</Button>
+      )}
+    </div>
+  );
+};

--- a/src/app/cardio-add/page.tsx
+++ b/src/app/cardio-add/page.tsx
@@ -1,0 +1,22 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "../../pages/api/auth/[...nextauth]";
+import { CardioAddPage } from "./CardioAddPage";
+import { Container, Heading, Navigation } from "../../components/server";
+
+export default async function Page() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect('/login');
+
+  return (
+    <>
+      <main className="md:mt-4">
+        <Heading />
+        <Navigation />
+        <Container>
+          <CardioAddPage />
+        </Container>
+      </main>
+    </>
+  );
+}

--- a/src/app/search-result/SearchResultPage.tsx
+++ b/src/app/search-result/SearchResultPage.tsx
@@ -54,7 +54,9 @@ export const SearchResultPage: React.FC = () => {
                                         reps={d.reps}
                                         sets={d.sets}
                                         note={d.note}
-                                        muscles={d.exercise.muscles.map(m => m.muscle)} /></Link>;
+                                        muscles={d.exercise.muscles.map(m => m.muscle)}
+                                        duration={d.duration}
+                                        calories={d.calories} /></Link>;
                                 })
                                 : <NoDataCard />}
                         </ListContainer>

--- a/src/app/workout-detail/WorkoutDetailPage.tsx
+++ b/src/app/workout-detail/WorkoutDetailPage.tsx
@@ -146,6 +146,8 @@ export const WorkoutDetailPage: React.FC = () => {
                             sets={data.sets}
                             note={data.note}
                             muscles={data.exercise.muscles.map(m => m.muscle)}
+                            duration={data.duration}
+                            calories={data.calories}
                         />
                     </div>
                     
@@ -155,15 +157,17 @@ export const WorkoutDetailPage: React.FC = () => {
                             text="#everyworkout"
                             title="EVERYWORKOUT"
                         />
-                        <Link 
-                            className="bg-white dark:bg-gray-800 text-gray-700 dark:text-white px-4 py-2 rounded-lg flex items-center justify-center gap-2 shadow-sm border border-gray-200 dark:border-gray-700 transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700" 
-                            href={`/exercise-detail?id=${data.exerciseId}`}
-                        >
-                            <ChartBarIcon className="w-5 h-5 text-blue-500" />
-                            <span>グラフを表示</span>
-                        </Link>
-                        <Link 
-                            className="bg-white dark:bg-gray-800 text-gray-700 dark:text-white px-4 py-2 rounded-lg flex items-center justify-center gap-2 shadow-sm border border-gray-200 dark:border-gray-700 transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700" 
+                        {data.duration == null && (
+                            <Link
+                                className="bg-white dark:bg-gray-800 text-gray-700 dark:text-white px-4 py-2 rounded-lg flex items-center justify-center gap-2 shadow-sm border border-gray-200 dark:border-gray-700 transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+                                href={`/exercise-detail?id=${data.exerciseId}`}
+                            >
+                                <ChartBarIcon className="w-5 h-5 text-blue-500" />
+                                <span>グラフを表示</span>
+                            </Link>
+                        )}
+                        <Link
+                            className="bg-white dark:bg-gray-800 text-gray-700 dark:text-white px-4 py-2 rounded-lg flex items-center justify-center gap-2 shadow-sm border border-gray-200 dark:border-gray-700 transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
                             href={`/search-result?exerciseId=${data.exerciseId}`}
                         >
                             <ListBulletIcon className="w-5 h-5 text-blue-500" />
@@ -171,7 +175,7 @@ export const WorkoutDetailPage: React.FC = () => {
                         </Link>
                     </div>
                     
-                    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md dark:border dark:border-gray-700 p-5">
+                    {data.duration == null && <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md dark:border dark:border-gray-700 p-5">
                         <Subheader content="最大記録の登録" variant="section" />
                         
                         <div className="mt-4 space-y-4">
@@ -218,7 +222,22 @@ export const WorkoutDetailPage: React.FC = () => {
                                 )}
                             </div>
                         </div>
-                    </div>
+                    </div>}
+                    {data.duration != null && (
+                        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md dark:border dark:border-gray-700 p-5">
+                            {deleteMutation.isLoading ? (
+                                <Loading />
+                            ) : (
+                                <Button
+                                    onClick={() => void deleteWorkout()}
+                                    variant="danger"
+                                    className="w-full"
+                                >
+                                    この記録を削除
+                                </Button>
+                            )}
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/src/app/workout-history/WorkoutHistoryPage.tsx
+++ b/src/app/workout-history/WorkoutHistoryPage.tsx
@@ -106,6 +106,8 @@ export const WorkoutHistoryPage: React.FC = () => {
                   sets={d.sets}
                   note={d.note}
                   muscles={d.exercise.muscles.map(m => m.muscle)}
+                  duration={d.duration}
+                  calories={d.calories}
                 /></Link>;
               })
               : <NoDataCard />}

--- a/src/app/workout-recorder/WorkoutRecorderPage.tsx
+++ b/src/app/workout-recorder/WorkoutRecorderPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 
 import { api } from "../../utils/api";
 import { Loading } from "../../components";
@@ -94,6 +95,14 @@ export const WorkoutRecorderPage: React.FC = () => {
                 </p>
             )}
             {!isEnd && (sets === "-1" ? <>
+                <div className="m-2 flex justify-end">
+                    <Link
+                        href="/cardio-add"
+                        className="text-sm text-blue-500 border border-blue-200 dark:border-blue-800 px-3 py-2 rounded-lg flex items-center gap-1 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                    >
+                        有酸素運動を記録する
+                    </Link>
+                </div>
                 <SetConfigForm
                     bodyParts={bodyParts || []}
                     muscles={muscles || []}

--- a/src/components/RecordCard.tsx
+++ b/src/components/RecordCard.tsx
@@ -14,7 +14,9 @@ type Props = {
   reps: number;
   sets: number;
   note: string | null;
-  muscles: Muscle[]
+  muscles: Muscle[];
+  duration?: number | null;
+  calories?: number | null;
 };
 
 export const RecordCard: React.FC<Props> = (props: Props) => {
@@ -24,7 +26,9 @@ export const RecordCard: React.FC<Props> = (props: Props) => {
     weight,
     reps,
     sets,
-    muscles
+    muscles,
+    duration,
+    calories,
   } = props;
   const dateDisplay = date.toISOString().split("T")[0];
   return (
@@ -45,18 +49,35 @@ export const RecordCard: React.FC<Props> = (props: Props) => {
         </div>
         <div className="col-span-12 my-3">
           <div className="flex justify-center items-center gap-2 divide-x">
-            <span className="w-20 flex flex-col items-center">
-              <span className="text-2xl font-extrabold text-[#42bfec]">{weight}</span>
-              <span className="text-gray-500 text-xs">kg</span>
-            </span>
-            <span className="w-20 flex flex-col items-center">
-              <span className="text-2xl font-extrabold text-[#42bfec]">{reps}</span>
-              <span className="text-gray-500 text-xs">reps</span>
-            </span>
-            <span className="w-20 flex flex-col items-center">
-              <span className="text-2xl font-extrabold text-[#42bfec]">{sets}</span>
-              <span className="text-gray-500 text-xs">sets</span>
-            </span>
+            {duration != null ? (
+              <>
+                <span className="w-20 flex flex-col items-center">
+                  <span className="text-2xl font-extrabold text-[#42bfec]">{duration}</span>
+                  <span className="text-gray-500 text-xs">分</span>
+                </span>
+                {calories != null && (
+                  <span className="w-20 flex flex-col items-center">
+                    <span className="text-2xl font-extrabold text-[#42bfec]">{calories}</span>
+                    <span className="text-gray-500 text-xs">kcal</span>
+                  </span>
+                )}
+              </>
+            ) : (
+              <>
+                <span className="w-20 flex flex-col items-center">
+                  <span className="text-2xl font-extrabold text-[#42bfec]">{weight}</span>
+                  <span className="text-gray-500 text-xs">kg</span>
+                </span>
+                <span className="w-20 flex flex-col items-center">
+                  <span className="text-2xl font-extrabold text-[#42bfec]">{reps}</span>
+                  <span className="text-gray-500 text-xs">reps</span>
+                </span>
+                <span className="w-20 flex flex-col items-center">
+                  <span className="text-2xl font-extrabold text-[#42bfec]">{sets}</span>
+                  <span className="text-gray-500 text-xs">sets</span>
+                </span>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/WorkoutCard.tsx
+++ b/src/components/WorkoutCard.tsx
@@ -18,11 +18,13 @@ type Props = {
     reps: number;
     sets: number;
     note: string | null;
-    muscles: Muscle[]
+    muscles: Muscle[];
+    duration?: number | null;
+    calories?: number | null;
 };
 
 export const WorkoutCard: React.FC<Props> = (props: Props) => {
-    const { id, date, exerciseName, weight, reps, sets, note, muscles } = props;
+    const { id, date, exerciseName, weight, reps, sets, note, muscles, duration, calories } = props;
     const dateDisplay = date
         ? new Date(date).toISOString().split("T")[0] || ""
         : "";
@@ -72,18 +74,35 @@ export const WorkoutCard: React.FC<Props> = (props: Props) => {
                     })}
                     <div className="flex justify-center items-center w-full">
                         <div className="flex justify-between items-center divide-x dark:divide-gray-500">
-                            <span className="w-20 flex flex-col items-center">
-                                <span className="text-2xl font-extrabold text-[#42bfec]">{weight}</span>
-                                <span className="text-gray-700 text-xs dark:text-gray-300">kg</span>
-                            </span>
-                            <span className="w-20 flex flex-col items-center">
-                                <span className="text-2xl font-extrabold text-[#42bfec]">{reps}</span>
-                                <span className="text-gray-700 text-xs dark:text-gray-300">reps</span>
-                            </span>
-                            <span className="w-20 flex flex-col items-center">
-                                <span className="text-2xl font-extrabold text-[#42bfec]">{sets}</span>
-                                <span className="text-gray-700 text-xs dark:text-gray-300">sets</span>
-                            </span>
+                            {duration != null ? (
+                                <>
+                                    <span className="w-20 flex flex-col items-center">
+                                        <span className="text-2xl font-extrabold text-[#42bfec]">{duration}</span>
+                                        <span className="text-gray-700 text-xs dark:text-gray-300">分</span>
+                                    </span>
+                                    {calories != null && (
+                                        <span className="w-20 flex flex-col items-center">
+                                            <span className="text-2xl font-extrabold text-[#42bfec]">{calories}</span>
+                                            <span className="text-gray-700 text-xs dark:text-gray-300">kcal</span>
+                                        </span>
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    <span className="w-20 flex flex-col items-center">
+                                        <span className="text-2xl font-extrabold text-[#42bfec]">{weight}</span>
+                                        <span className="text-gray-700 text-xs dark:text-gray-300">kg</span>
+                                    </span>
+                                    <span className="w-20 flex flex-col items-center">
+                                        <span className="text-2xl font-extrabold text-[#42bfec]">{reps}</span>
+                                        <span className="text-gray-700 text-xs dark:text-gray-300">reps</span>
+                                    </span>
+                                    <span className="w-20 flex flex-col items-center">
+                                        <span className="text-2xl font-extrabold text-[#42bfec]">{sets}</span>
+                                        <span className="text-gray-700 text-xs dark:text-gray-300">sets</span>
+                                    </span>
+                                </>
+                            )}
                         </div>
                     </div>
 

--- a/src/server/api/routers/workout.ts
+++ b/src/server/api/routers/workout.ts
@@ -22,11 +22,13 @@ export const workoutRouter = createTRPCRouter({
     .input(
       z.object({
         date: z.string().datetime(),
-        weight: z.number(),
+        weight: z.number().optional(),
         reps: z.number(),
         sets: z.number(),
         note: z.string().max(500),
         exerciseId: z.number(),
+        duration: z.number().int().min(1).optional(),
+        calories: z.number().min(0).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -34,11 +36,13 @@ export const workoutRouter = createTRPCRouter({
         data: {
           userId: ctx.session.user.id,
           date: input.date,
-          weight: input.weight,
+          weight: input.weight ?? null,
           reps: input.reps,
           sets: input.sets,
           note: input.note,
           exerciseId: input.exerciseId,
+          duration: input.duration ?? null,
+          calories: input.calories ?? null,
           weeklyReportPublished: false
         },
       });


### PR DESCRIPTION
- Workout テーブルに duration（分）と calories（kcal）フィールドを追加
- 有酸素運動カテゴリ（有酸素運動 BodyPart、全身 Muscle）と7種目を DB に追加 （ランニング、ウォーキング、サイクリング、水泳、ロープジャンプ、エアロバイク、ローイングマシン）
- /cardio-add ページ: 日付・種目・時間・消費カロリー・メモを記録するフォーム
- workout.add API: weight を optional 化し duration/calories を受け付けるよう拡張
- WorkoutCard / RecordCard: duration が存在する場合は分・kcal 表示に切り替え
- WorkoutDetailPage: 有酸素記録では最大記録登録・グラフ表示を非表示にし削除ボタンのみ表示
- WorkoutRecorderPage: 設定フォーム上部に「有酸素運動を記録する」リンクを追加

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP