### PR TITLE
fix: 有酸素種目マイグレーションのシーケンス衝突を修正

### DIFF
--- a/prisma/migrations/20260509000001_add_cardio_exercises/migration.sql
+++ b/prisma/migrations/20260509000001_add_cardio_exercises/migration.sql
@@ -1,18 +1,35 @@
 -- Add aerobic/cardio exercise category and exercises
+-- Reset sequences to max existing IDs to avoid primary key conflicts
 
-INSERT INTO "BodyPart" ("name") VALUES ('有酸素運動');
+SELECT setval('"BodyPart_id_seq"', GREATEST((SELECT MAX(id) FROM "BodyPart"), 1));
+SELECT setval('"Muscle_id_seq"', GREATEST((SELECT MAX(id) FROM "Muscle"), 1));
+SELECT setval('"Exercise_id_seq"', GREATEST((SELECT MAX(id) FROM "Exercise"), 1));
+SELECT setval('"ExerciseMuscle_id_seq"', GREATEST((SELECT MAX(id) FROM "ExerciseMuscle"), 1));
+
+INSERT INTO "BodyPart" ("name")
+  SELECT '有酸素運動' WHERE NOT EXISTS (
+    SELECT 1 FROM "BodyPart" WHERE name = '有酸素運動'
+  );
 
 INSERT INTO "Muscle" ("name", "name_kana", "bodyPartId")
-  SELECT '全身', 'ぜんしん', id FROM "BodyPart" WHERE name = '有酸素運動';
+  SELECT '全身', 'ぜんしん', id FROM "BodyPart" WHERE name = '有酸素運動'
+  AND NOT EXISTS (
+    SELECT 1 FROM "Muscle" WHERE name = '全身'
+  );
 
-INSERT INTO "Exercise" ("name") VALUES
-  ('ランニング'),
-  ('ウォーキング'),
-  ('サイクリング'),
-  ('水泳'),
-  ('ロープジャンプ'),
-  ('エアロバイク'),
-  ('ローイングマシン');
+INSERT INTO "Exercise" ("name")
+  SELECT v.name FROM (VALUES
+    ('ランニング'),
+    ('ウォーキング'),
+    ('サイクリング'),
+    ('水泳'),
+    ('ロープジャンプ'),
+    ('エアロバイク'),
+    ('ローイングマシン')
+  ) AS v(name)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM "Exercise" WHERE "Exercise".name = v.name
+  );
 
 INSERT INTO "ExerciseMuscle" ("exerciseId", "muscleId", "is_main")
   SELECT e.id, m.id, true
@@ -21,4 +38,8 @@ INSERT INTO "ExerciseMuscle" ("exerciseId", "muscleId", "is_main")
     'ランニング', 'ウォーキング', 'サイクリング', '水泳',
     'ロープジャンプ', 'エアロバイク', 'ローイングマシン'
   )
-  AND m.name = '全身';
+  AND m.name = '全身'
+  AND NOT EXISTS (
+    SELECT 1 FROM "ExerciseMuscle"
+    WHERE "exerciseId" = e.id AND "muscleId" = m.id
+  );


### PR DESCRIPTION
Exercise シーケンスが DB 上の最大 ID より低い場合に主キー重複エラーが
発生するため、INSERT 前に各テーブルのシーケンスを現在の最大 ID に
リセットするよう修正。また重複行を防ぐ NOT EXISTS ガードを追加。

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP