### PR TITLE
fix: CIで失敗済みマイグレーションを解決してから deploy するよう修正

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -24,6 +24,11 @@ jobs:
 
       - run: rm -rf node_modules/.prisma
 
+      - name: Resolve Failed Migration
+        run: npx prisma migrate resolve --rolled-back "20260509000001_add_cardio_exercises" || true
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+
       - name: Deploy Migrations
         run: npx prisma migrate deploy
         env:


### PR DESCRIPTION
20260509000001_add_cardio_exercises が failed 状態で記録されているため migrate deploy がブロックされる問題を修正。
Deploy Migrations ステップの前に prisma migrate resolve --rolled-back を 実行してリセットする（既に applied の場合はエラーを無視）。

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP