### PR TITLE
ci: StorybookテストをGitHub Actionsに追加

### DIFF
--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -1,0 +1,39 @@
+name: Storybook Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build Storybook
+        run: yarn build-storybook
+
+      - name: Serve Storybook
+        run: npx serve storybook-static --listen 6006 &
+
+      - name: Wait for Storybook to be ready
+        run: npx wait-on http://127.0.0.1:6006 --timeout 60000
+
+      - name: Run Storybook tests
+        run: yarn test-storybook --url http://127.0.0.1:6006


### PR DESCRIPTION
PR・mainへのpush時にplay関数を含む全ストーリーをPlaywrightで自動実行する。

- build-storybookで静的ビルド後、serveでローカル配信
- wait-onでサーバー起動を待機してからtest-storybookを実行
- ubuntu-latest + Chromiumで動作

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP