### PR TITLE
feat(timer): ナビゲーション間でタイマー状態を sessionStorage に永続化

### DIFF
--- a/src/app/timer/TimerPageClient.tsx
+++ b/src/app/timer/TimerPageClient.tsx
@@ -1,17 +1,71 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Timer, Button, BackButton } from "../../components";
 import { Container, Heading, Navigation } from "../../components/server";
+
+const TIMER_KEY = 'everyworkout_timer_state';
+
+type SavedTimer =
+  | { state: 'running'; expiryAt: number; duration: number }
+  | { state: 'paused'; remainingSeconds: number; duration: number };
 
 export const TimerPageClient: React.FC = () => {
   const [expiryTD, setExpiryTD] = useState<number>(120);
   const [isStarted, setStarted] = useState<boolean>(false);
+  const [autoStart, setAutoStart] = useState<boolean>(false);
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem(TIMER_KEY);
+    if (!raw) return;
+    try {
+      const saved = JSON.parse(raw) as SavedTimer;
+      if (saved.state === 'running') {
+        const remaining = Math.floor((saved.expiryAt - Date.now()) / 1000);
+        if (remaining > 0) {
+          setExpiryTD(remaining);
+          setAutoStart(true);
+          setStarted(true);
+        } else {
+          sessionStorage.removeItem(TIMER_KEY);
+        }
+      } else {
+        setExpiryTD(saved.remainingSeconds);
+        setAutoStart(false);
+        setStarted(true);
+      }
+    } catch {
+      sessionStorage.removeItem(TIMER_KEY);
+    }
+  }, []);
 
   const modifyExpiryTD = (delta: number) => {
     const newVal = Math.max(0, expiryTD + delta);
     setExpiryTD(newVal);
-  }
+  };
+
+  const handleStart = () => {
+    const expiryAt = Date.now() + expiryTD * 1000;
+    sessionStorage.setItem(TIMER_KEY, JSON.stringify({
+      state: 'running', expiryAt, duration: expiryTD,
+    } satisfies SavedTimer));
+    setAutoStart(false);
+    setStarted(true);
+  };
+
+  const handleExpire = () => {
+    sessionStorage.removeItem(TIMER_KEY);
+  };
+
+  const handlePause = (remainingSeconds: number) => {
+    sessionStorage.setItem(TIMER_KEY, JSON.stringify({
+      state: 'paused', remainingSeconds, duration: expiryTD,
+    } satisfies SavedTimer));
+  };
+
+  const handleReset = () => {
+    sessionStorage.removeItem(TIMER_KEY);
+  };
 
   return (
     <>
@@ -34,14 +88,19 @@ export const TimerPageClient: React.FC = () => {
                   </div>
                 </div>
                 <div className="flex justify-center items-center text-xl mt-1">
-                  <Button onClick={() => void setStarted(true)}>開始</Button>
+                  <Button onClick={handleStart}>開始</Button>
                 </div>
               </>
             }
             {
-              isStarted && <>
-                <Timer expiryTimeDelta={expiryTD}></Timer>
-              </>
+              isStarted &&
+              <Timer
+                expiryTimeDelta={expiryTD}
+                autoStart={autoStart}
+                onExpire={handleExpire}
+                onPause={handlePause}
+                onReset={handleReset}
+              />
             }
           </div>
         </Container>

--- a/src/app/workout-recorder/SetRecorder.tsx
+++ b/src/app/workout-recorder/SetRecorder.tsx
@@ -6,6 +6,12 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import type { WorkoutProp } from "../../components/types";
 import { Button, Subheader, Timer } from "../../components";
 
+const INTERVAL_KEY = 'everyworkout_interval_timer';
+
+type SavedIntervalTimer =
+  | { state: 'running'; expiryAt: number }
+  | { state: 'paused'; remainingSeconds: number };
+
 type Props = {
     endSets: (sets: string) => void;
 };
@@ -22,6 +28,14 @@ export function SetRecorder(props: Props) {
     const [selectedExerciseId, selectExerciseId] = useState(-1);
     const [selectedExerciseName, selectExerciseName] = useState("");
     const [selectedBodyPartId, selectBodyPartId] = useState(-1);
+    const [restoredSeconds, setRestoredSeconds] = useState<number | null>(null);
+    const [autoStartTimer, setAutoStartTimer] = useState<boolean>(false);
+
+    const clearIntervalTimer = () => {
+        sessionStorage.removeItem(INTERVAL_KEY);
+        setRestoredSeconds(null);
+        setAutoStartTimer(false);
+    };
 
     const saveSession = (currentSet: string) => {
         const data: WorkoutProp = {
@@ -38,6 +52,7 @@ export function SetRecorder(props: Props) {
     };
 
     const onPrevSet = () => {
+        clearIntervalTimer();
         const tmp = Math.max(parseInt(sets) - 1, 0);
         setSets(tmp.toString());
         saveSession(tmp.toString());
@@ -45,6 +60,7 @@ export function SetRecorder(props: Props) {
     };
 
     const onNextSet = () => {
+        clearIntervalTimer();
         const tmp = parseInt(sets) + 1;
         setSets(tmp.toString());
         saveSession(tmp.toString());
@@ -56,6 +72,7 @@ export function SetRecorder(props: Props) {
     };
 
     const clear = () => {
+        clearIntervalTimer();
         window.sessionStorage.removeItem("workout");
         router.push('/workout-menu');
     };
@@ -73,7 +90,26 @@ export function SetRecorder(props: Props) {
             setExpiryTimeDelta(workout.expiryTimeDelta);
             setSets(workout.sets);
         }
-    }, [setDate, selectExerciseId, selectExerciseName, selectBodyPartId, setWeight, setReps, setExpiryTimeDelta, setSets]);
+
+        const raw = sessionStorage.getItem(INTERVAL_KEY);
+        if (!raw) return;
+        try {
+            const saved = JSON.parse(raw) as SavedIntervalTimer;
+            if (saved.state === 'running') {
+                const remaining = Math.floor((saved.expiryAt - Date.now()) / 1000);
+                if (remaining > 0) {
+                    setRestoredSeconds(remaining);
+                    setAutoStartTimer(true);
+                } else {
+                    sessionStorage.removeItem(INTERVAL_KEY);
+                }
+            } else {
+                setRestoredSeconds(saved.remainingSeconds);
+            }
+        } catch {
+            sessionStorage.removeItem(INTERVAL_KEY);
+        }
+    }, []);
 
     return (<>
         <div className="dark:text-white p-2 md:p-0">
@@ -91,7 +127,15 @@ export function SetRecorder(props: Props) {
             </div>
             <Subheader content="インターバル" variant="section"/>
             <div>
-                <Timer expiryTimeDelta={expiryTimeDelta} onExpire={onNextSet}></Timer>
+                <Timer
+                    expiryTimeDelta={restoredSeconds ?? expiryTimeDelta}
+                    autoStart={autoStartTimer}
+                    onExpire={() => { clearIntervalTimer(); onNextSet(); }}
+                    onPause={(remaining) => {
+                        sessionStorage.setItem(INTERVAL_KEY, JSON.stringify({ state: 'paused', remainingSeconds: remaining } satisfies SavedIntervalTimer));
+                    }}
+                    onReset={clearIntervalTimer}
+                />
             </div>
             <div className="flex flex-col justify-center gap-2 mt-2">
                 <Button onClick={handleEndButtonClick}>セットを終了して記録</Button>

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTimer } from "react-timer-hook";
 import { ArrowPathIcon, PlayIcon, PauseIcon } from "@heroicons/react/20/solid";
 import { useNotification } from "../hooks/useNotification";
@@ -9,15 +9,22 @@ export interface TimerProps {
   onExpire?: () => void;
   variant?: "standard" | "compact" | "countdown";
   className?: string;
+  autoStart?: boolean;
+  onPause?: (remainingSeconds: number) => void;
+  onReset?: () => void;
 }
 
 export const Timer: React.FC<TimerProps> = ({
   expiryTimeDelta,
   onExpire: onTimerExpire,
   variant = "standard",
-  className
+  className,
+  autoStart = false,
+  onPause,
+  onReset,
 }) => {
   const [isExpired, setExpired] = useState<boolean>(false);
+  const isInitialMount = useRef(true);
   const tmp = new Date().getSeconds() + expiryTimeDelta;
   const expiryTimestamp = new Date();
   expiryTimestamp.setSeconds(tmp);
@@ -64,8 +71,15 @@ export const Timer: React.FC<TimerProps> = ({
   // }, [restart]);
 
   useEffect(() => {
-    const now = new Date();
-    resetInterval(now, expiryTimeDelta);
+    const ts = new Date();
+    ts.setSeconds(ts.getSeconds() + expiryTimeDelta);
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      restart(ts, autoStart);
+    } else {
+      restart(ts, false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expiryTimeDelta]);
 
   // Base styles for all timer variants
@@ -115,16 +129,16 @@ export const Timer: React.FC<TimerProps> = ({
         >
           <PlayIcon className={`${iconStyle} hover:scale-110 active:scale-95`} />
         </button>
-        <button 
-          className={controlButtonStyle} 
-          onClick={pause}
+        <button
+          className={controlButtonStyle}
+          onClick={() => { pause(); onPause?.(minutes * 60 + seconds); }}
           aria-label="一時停止"
         >
           <PauseIcon className={`${iconStyle} hover:scale-110 active:scale-95`} />
         </button>
-        <button 
-          className={controlButtonStyle} 
-          onClick={() => resetInterval(new Date(), expiryTimeDelta)}
+        <button
+          className={controlButtonStyle}
+          onClick={() => { resetInterval(new Date(), expiryTimeDelta); onReset?.(); }}
           aria-label="リセット"
         >
           <ArrowPathIcon className={`${iconStyle} hover:rotate-180`} />


### PR DESCRIPTION
Timer コンポーネントに autoStart / onPause / onReset の任意 props を追加し、 初回マウント時のみ autoStart を反映するよう useRef で制御。

TimerPageClient: 実行中は絶対終了時刻、一時停止中は残り秒数を
everyworkout_timer_state キーに保存。戻ったとき自動復元・自動再開。

SetRecorder: インターバルタイマー状態を everyworkout_interval_timer キーに 保存（ワークアウトデータの workout キーとは分離）。セット変更時はキーを削除。

https://claude.ai/code/session_01HP7ZamxyKC9npVthF4CxoP